### PR TITLE
Implement Instagram token refresh

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,14 +2,15 @@ import express, { Request, Response } from "express";
 import axios from "axios";
 import cors from "cors";
 import dotenv from "dotenv";
+import { getAccessToken } from "./token";
 
 dotenv.config();
 
 const app = express();
 app.use(cors());
 
-const INSTAGRAM_ACCESS_TOKEN = process.env.INSTAGRAM_ACCESS_TOKEN as string;
 const INSTAGRAM_ACCOUNT_ID = process.env.INSTAGRAM_ACCOUNT_ID as string;
+const INSTAGRAM_ACCESS_TOKEN = process.env.INSTAGRAM_ACCESS_TOKEN as string;
 
 if (!INSTAGRAM_ACCESS_TOKEN || !INSTAGRAM_ACCOUNT_ID) {
   console.error("❌ Error: Falta configurar INSTAGRAM_ACCESS_TOKEN o INSTAGRAM_ACCOUNT_ID en .env");
@@ -19,12 +20,13 @@ if (!INSTAGRAM_ACCESS_TOKEN || !INSTAGRAM_ACCOUNT_ID) {
 // **🔹 API que devuelve imágenes de Instagram al frontend**
 app.get("/api/instagram-posts", async (req: Request, res: Response) => {
   try {
-    console.log(`📸 Solicitando imágenes de Instagram con token: ${INSTAGRAM_ACCESS_TOKEN}`);
+    const token = getAccessToken();
+    console.log(`📸 Solicitando imágenes de Instagram con token: ${token}`);
 
     const response = await axios.get(`https://graph.instagram.com/${INSTAGRAM_ACCOUNT_ID}/media`, {
       params: {
         fields: "id,caption,media_type,media_url,permalink",
-        access_token: INSTAGRAM_ACCESS_TOKEN,
+        access_token: token,
       },
     });
 

--- a/src/token.ts
+++ b/src/token.ts
@@ -1,0 +1,32 @@
+import axios from "axios";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+let accessToken: string = process.env.INSTAGRAM_ACCESS_TOKEN as string;
+
+export const getAccessToken = () => accessToken;
+
+export async function refreshAccessToken() {
+  try {
+    const response = await axios.get(
+      "https://graph.instagram.com/refresh_access_token",
+      {
+        params: {
+          grant_type: "ig_refresh_token",
+          access_token: accessToken,
+        },
+      }
+    );
+    accessToken = response.data.access_token;
+    console.log("🔄 Token de Instagram actualizado");
+  } catch (error) {
+    console.error("❌ Error actualizando el token:", error);
+  }
+}
+
+const REFRESH_INTERVAL_MS = 25 * 60 * 1000; // 25 minutos
+
+if (accessToken) {
+  setInterval(refreshAccessToken, REFRESH_INTERVAL_MS);
+}


### PR DESCRIPTION
## Summary
- add a token helper that refreshes Instagram Basic Display API token every 25 minutes
- use the token helper in the existing API route

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687c029a3f608321988877839688a9a4